### PR TITLE
add initial working version of dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM continuumio/miniconda3:4.7.10
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY requirements.txt /usr/src/app/
+
+RUN conda install -c anaconda scipy>=1.2.1 numpy=1.16.1 pandas=0.24.2
+RUN pip install -r requirements.txt
+
+COPY . /usr/src/app
+RUN pip install .
+
+CMD ["/bin/bash"]
+


### PR DESCRIPTION
Resulting image is way too big (1.93GB), but is at least functional for now. Can probably do some additional cleanup after installing dependencies.
